### PR TITLE
Add size change automation to Enlarge/reduce

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -20,4 +20,13 @@ export default class Constants {
     IN_ONE_DAY: 86400,
     IN_ONE_WEEK: 604800,
   };
+
+  static SIZES_ORDERED = [
+    'tiny',
+    'sm',
+    'med',
+    'lg',
+    'huge',
+    'grg',
+  ];
 }

--- a/scripts/effects/dynamic-effects-adder.js
+++ b/scripts/effects/dynamic-effects-adder.js
@@ -15,6 +15,9 @@ export default class DynamicEffectsAdder {
       case 'encumbered':
         this._addLowerMovementEffects({ effect, actor, value: 10 });
         break;
+      case 'enlarge':
+        this._addEnlargeEffects(effect, actor);
+        break;
       case 'heavily encumbered':
         this._addLowerMovementEffects({ effect, actor, value: 20 });
         break;
@@ -27,9 +30,8 @@ export default class DynamicEffectsAdder {
       case 'ray of frost':
         this._addLowerMovementEffects({ effect, actor, value: 10 });
         break;
-      case 'enlarge':
       case 'reduce':
-        this._addEnlargeReduceEffect(effect, actor);
+        this._addReduceEffects(effect, actor);
         break;
     }
   }
@@ -68,18 +70,22 @@ export default class DynamicEffectsAdder {
     });
   }
 
-  _addEnlargeReduceEffect(effect, actor) {
+  _addEnlargeEffects(effect, actor) {
+    const size = actor.data.data.traits.size;
+    const index = Constants.SIZES_ORDERED.indexOf(size);
+    
+    this._addSizeChangeEffects(effect, Math.min(Constants.SIZES_ORDERED.length - 1, index + 1));
+  }
 
-    let size = actor.data.data.traits.size;
-    let index = Constants.SIZES_ORDERED.indexOf(size);
+  _addReduceEffects(effect, actor) {
+    const size = actor.data.data.traits.size;
+    const index = Constants.SIZES_ORDERED.indexOf(size);
 
-    if (effect.name.toLowerCase() === 'enlarge') {
-      index = Math.min(Constants.SIZES_ORDERED.length - 1, index + 1);
-    } else if (effect.name.toLowerCase() === 'reduce') {
-      index = Math.max(0, index - 1);
-    }
+    this._addSizeChangeEffects(effect, Math.max(0, index - 1));
+  }
 
-    size = Constants.SIZES_ORDERED[index];
+  _addSizeChangeEffects(effect, sizeIndex) {
+    const size = Constants.SIZES_ORDERED[sizeIndex];
     const tokenSize = game.dnd5e.config.tokenSizes[size];
 
     effect.changes.push({

--- a/scripts/effects/dynamic-effects-adder.js
+++ b/scripts/effects/dynamic-effects-adder.js
@@ -1,3 +1,5 @@
+import Constants from '../constants.js';
+
 /**
  * Handles adding dynamic effects for certain effects
  */
@@ -24,6 +26,10 @@ export default class DynamicEffectsAdder {
         break;
       case 'ray of frost':
         this._addLowerMovementEffects({ effect, actor, value: 10 });
+        break;
+      case 'enlarge':
+      case 'reduce':
+        this._addEnlargeReduceEffect(effect, actor);
         break;
     }
   }
@@ -60,6 +66,42 @@ export default class DynamicEffectsAdder {
       mode: CONST.ACTIVE_EFFECT_MODES.ADD,
       value: movement.walk > value ? `-${value}` : `-${movement.walk}`,
     });
+  }
+
+  _addEnlargeReduceEffect(effect, actor) {
+
+    let size = actor.data.data.traits.size;
+    let index = Constants.SIZES_ORDERED.indexOf(size);
+
+    if (effect.name.toLowerCase() === 'enlarge') {
+      index = Math.min(Constants.SIZES_ORDERED.length - 1, index + 1);
+    } else if (effect.name.toLowerCase() === 'reduce') {
+      index = Math.max(0, index - 1);
+    }
+
+    size = Constants.SIZES_ORDERED[index];
+    const tokenSize = game.dnd5e.config.tokenSizes[size];
+
+    effect.changes.push({
+      key: 'data.traits.size',
+      mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+      value: size,
+    });
+
+    effect.atlChanges.push(
+      ...[
+        {
+          key: 'ATL.width',
+          mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+          value: tokenSize,
+        },
+        {
+          key: 'ATL.height',
+          mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+          value: tokenSize,
+        },
+      ]
+    );
   }
 
   _addLongstriderEffects(effect, actor) {

--- a/scripts/effects/effect-definitions.js
+++ b/scripts/effects/effect-definitions.js
@@ -1107,10 +1107,10 @@ export default class EffectDefinitions {
       description:
         'Add 1d4 to damage and advantage on strength checks and strength saving throws for 1 minute',
       icon: 'systems/dnd5e/icons/spells/link-blue-2.jpg',
+      isDynamic: true,
       isViewable: this._settings.showNestedEffects,
       seconds: Constants.SECONDS.IN_ONE_MINUTE,
       changes: [
-        // TODO data.traits.size
         {
           key: 'data.bonuses.weapon.damage',
           mode: CONST.ACTIVE_EFFECT_MODES.ADD,
@@ -1136,10 +1136,10 @@ export default class EffectDefinitions {
       description:
         'Subtract 1d4 from damage and disadvantage on strength checks and strength saving throws for 1 minute',
       icon: 'systems/dnd5e/icons/spells/link-blue-2.jpg',
+      isDynamic: true,
       isViewable: this._settings.showNestedEffects,
       seconds: Constants.SECONDS.IN_ONE_MINUTE,
       changes: [
-        // TODO data.traits.size
         {
           key: 'data.bonuses.weapon.damage',
           mode: CONST.ACTIVE_EFFECT_MODES.ADD,


### PR DESCRIPTION
This MR aims to provide automation of token sizes for the spell Enlarge/Reduce.

The token sizes and actor sizes label are [taken from the DND5e game system module](https://gitlab.com/foundrynet/dnd5e/-/blob/master/module/config.js#L277).

This functionality needs "Size adjustment with flags" to be enabled in ATL.

Known issues:
* Since the size changes are dynamic, the fact that they are ATL dependent doesn't appear on the UI.
* When the token changes size, the little floating text `+Enlarge` or `-Enlarge` doesn't appear.

I only saw Issue #5 and your response to it after I was done with this, so I'd understand perfectly if it doesn't fit your vision for the module. LMK what you think :) .
