### PR TITLE
refactor: use core drag drop event data for non-nested effects

### DIFF
--- a/scripts/app/convenient-effects-controller.js
+++ b/scripts/app/convenient-effects-controller.js
@@ -337,12 +337,31 @@ export default class ConvenientEffectsController {
 
   /**
    * Handles starting the drag for effect items
+   * Populates the dataTransfer with Foundry's expected ActiveEffect type
+   * and data to make drag drop work with no further handling.
    *
    * @param {DragEvent} event - event that corresponds to the drag start
    */
   onEffectDragStart(event) {
     const effectName = event.target.dataset.effectName;
-    event.dataTransfer.setData('text/plain', JSON.stringify({ effectName }));
+
+    const effect = game.dfreds.effectInterface.findEffectByName(effectName);
+
+    // special handling for nested effects
+    if (effect.nestedEffects.length) {
+      event.dataTransfer.setData('text/plain', JSON.stringify({
+        effectName,
+      }));
+      return;
+    }
+
+    // otherwise use core default format
+    const effectData = effect.convertToActiveEffectData();
+
+    event.dataTransfer.setData('text/plain', JSON.stringify({
+      type: "ActiveEffect",
+      data: effectData
+    }));
   }
 
   /**

--- a/scripts/app/convenient-effects-controller.js
+++ b/scripts/app/convenient-effects-controller.js
@@ -337,8 +337,8 @@ export default class ConvenientEffectsController {
 
   /**
    * Handles starting the drag for effect items
-   * Populates the dataTransfer with Foundry's expected ActiveEffect type
-   * and data to make drag drop work with no further handling.
+   * For non-nested effects, populates the dataTransfer with Foundry's expected
+   * ActiveEffect type and data to make non-nested effects behave as core does
    *
    * @param {DragEvent} event - event that corresponds to the drag start
    */

--- a/scripts/app/convenient-effects-controller.js
+++ b/scripts/app/convenient-effects-controller.js
@@ -359,6 +359,7 @@ export default class ConvenientEffectsController {
     const effectData = effect.convertToActiveEffectData();
 
     event.dataTransfer.setData('text/plain', JSON.stringify({
+      effectName,
       type: "ActiveEffect",
       data: effectData
     }));

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -97,7 +97,7 @@ Hooks.on('getSceneControlButtons', (controls) => {
  * Handle creating a chat message if an effect is added
  */
 Hooks.on('preCreateActiveEffect', (activeEffect, config, userId) => {
-  if (!activeEffect?.data?.flags?.isConvenient) return;
+  if (!activeEffect?.data?.flags?.isConvenient || !(activeEffect?.parent instanceof Actor)) return;
 
   const chatHandler = new ChatHandler();
   chatHandler.createChatForEffect({
@@ -112,7 +112,7 @@ Hooks.on('preCreateActiveEffect', (activeEffect, config, userId) => {
  * Handle adding any actor data changes when an active effect is added to an actor
  */
 Hooks.on('createActiveEffect', (activeEffect, config, userId) => {
-  if (!activeEffect?.data?.flags?.isConvenient) return;
+  if (!activeEffect?.data?.flags?.isConvenient || !(activeEffect?.parent instanceof Actor)) return;
 
   if (activeEffect?.data?.flags?.requiresActorUpdate) {
     game.dfreds.effectInterface.addActorDataChanges(
@@ -126,7 +126,7 @@ Hooks.on('createActiveEffect', (activeEffect, config, userId) => {
  * Handle creating a chat message if an effect has expired or was removed
  */
 Hooks.on('preDeleteActiveEffect', (activeEffect, config, userId) => {
-  if (!activeEffect?.data?.flags?.isConvenient) return;
+  if (!activeEffect?.data?.flags?.isConvenient || !(activeEffect?.parent instanceof Actor)) return;
 
   const isExpired =
     activeEffect?.duration?.remaining !== null &&
@@ -145,7 +145,7 @@ Hooks.on('preDeleteActiveEffect', (activeEffect, config, userId) => {
  * Handle removing any actor data changes when an active effect is deleted from an actor
  */
 Hooks.on('deleteActiveEffect', (activeEffect, config, userId) => {
-  if (!activeEffect?.data?.flags?.isConvenient) return;
+  if (!activeEffect?.data?.flags?.isConvenient || !(activeEffect?.parent instanceof Actor)) return;
 
   if (activeEffect?.data?.flags?.requiresActorUpdate) {
     game.dfreds.effectInterface.removeActorDataChanges(
@@ -196,6 +196,11 @@ Hooks.on('hotbarDrop', (bar, data, slot) => {
  */
 Hooks.on('dropActorSheetData', (actor, actorSheetCharacter, data) => {
   if (!data.effectName) return;
+
+  const effect = game.dfreds.effectInterface.findEffectByName(data.effectName);
+
+  // core will handle the drop since we are not using a nested effect
+  if (!effect.nestedEffects.length) return;
 
   game.dfreds.effectInterface.addEffect({
     effectName: data.effectName,


### PR DESCRIPTION
A rehash of #100, preferring to use the same AE data transfer as core when not dragging a nested effect.

This change allows non-nested effects to be handled by Core's own drag and drop handlers.

When coupled with the [`Drop Effects on Items`](https://github.com/ElfFriend-DnD/foundryvtt-drop-effects-on-items) module, this allows convenient effects to be placed directly onto items. When further coupled with [`Item Effects to Chat D&D5e`](https://github.com/ElfFriend-DnD/foundryvtt-item-effects-to-chat-5e), these effects can be applied directly from chat with no further handling on this module's part.

Video demo of what this change allows with those two modules also enabled in the world:

https://user-images.githubusercontent.com/7644614/153972573-c855947b-3a28-484b-b681-566665c910bc.mp4


