### PR TITLE
Fix drag/drop issue for macros

### DIFF
--- a/scripts/app/convenient-effects-controller.js
+++ b/scripts/app/convenient-effects-controller.js
@@ -369,26 +369,10 @@ export default class ConvenientEffectsController {
 
     const effect = game.dfreds.effectInterface.findEffectByName(effectName);
 
-    // special handling for nested effects
-    if (effect.nestedEffects.length) {
-      event.dataTransfer.setData(
-        'text/plain',
-        JSON.stringify({
-          effectName,
-        })
-      );
-      return;
-    }
-
-    // otherwise use core default format
-    const effectData = effect.convertToActiveEffectData();
-
     event.dataTransfer.setData(
       'text/plain',
       JSON.stringify({
         effectName,
-        type: 'ActiveEffect',
-        data: effectData,
       })
     );
   }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -223,11 +223,6 @@ Hooks.on('hotbarDrop', (_bar, data, slot) => {
 Hooks.on('dropActorSheetData', (actor, _actorSheetCharacter, data) => {
   if (!data.effectName) return;
 
-  const effect = game.dfreds.effectInterface.findEffectByName(data.effectName);
-
-  // core will handle the drop since we are not using a nested effect
-  if (!effect.nestedEffects.length) return;
-
   game.dfreds.effectInterface.addEffect({
     effectName: data.effectName,
     uuid: actor.uuid,


### PR DESCRIPTION
DND5e now handles dragging and dropping active effects from character
or item sheets onto the macro bar. This caused two macros to be created
(one from dnd5e and one from CE).

This fixes the issue by not allowing core to handle the ActiveEffect
drag and drop anymore.