### PR TITLE
ATE v10 changes

### DIFF
--- a/scripts/effects/effect-definitions.js
+++ b/scripts/effects/effect-definitions.js
@@ -1227,9 +1227,15 @@ export default class EffectDefinitions {
       ],
       atlChanges: [
         {
-          key: this._createAtlEffectKey('ATL.dimSight'),
+          key: this._createAtlEffectKey('ATL.sight.range'),
           mode: CONST.ACTIVE_EFFECT_MODES.UPGRADE,
           value: '60',
+          priority: 5,
+        },
+        {
+          key: this._createAtlEffectKey('ATL.sight.visionMode'),
+          mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+          value: 'darkvision',
           priority: 5,
         },
       ],

--- a/scripts/effects/effect-definitions.js
+++ b/scripts/effects/effect-definitions.js
@@ -3571,30 +3571,10 @@ export default class EffectDefinitions {
 
   _createAtlEffectKey(key) {
     let result = key;
-    const version = game.version.split('.')[0];
+    const version = game.release.generation;
 
-    if (version == '10') {
+    if (version >= 9) {
       switch (key) {
-        case 'ATL.preset':
-          break;
-        case 'ATL.brightSight':
-          break;
-        case 'ATL.dimSight':
-          break;
-        case 'ATL.height':
-          break;
-        case 'ATl.img':
-          break;
-        case 'ATL.mirrorX':
-          break;
-        case 'ATL.mirrorY':
-          break;
-        case 'ATL.rotation':
-          break;
-        case 'ATL.scale':
-          break;
-        case 'ATL.width':
-          break;
         case 'ATL.dimLight':
           result = 'ATL.light.dim';
           break;
@@ -3612,6 +3592,16 @@ export default class EffectDefinitions {
           break;
         case 'ATL.lightAngle':
           result = 'ATL.light.angle';
+          break;
+      }
+    }
+    if (version >= 10) {
+      switch (key) {
+        case 'ATL.sightAngle':
+          result = 'ATL.sight.angle';
+          break;
+        case 'ATL.vision':
+          result = 'ATL.sight.enabled';
           break;
       }
     }


### PR DESCRIPTION
Update the `_createAtlEffectKey` function to have v9 and v10 sections. I also removed the existing ones that weren't renamed in v9. While `ATL.dimSight` and `ATL.brightSight` aren't used anymore, they aren't a simple rename so it's probably better that we use the new keys directly. That's why I made the change I did to Darkvision, plus adding the new `visionMode` in there as well.