### PR TITLE
Fix for Alt Token Visibility error

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -230,7 +230,7 @@ Hooks.on(
     const settings = new Settings();
 
     // Only add nested effects if the effect exists on the custom effect item
-    if (activeEffectConfig.object.parent.id != settings.customEffectsItemId)
+    if (!activeEffectConfig.object.parent || activeEffectConfig.object.parent.id != settings.customEffectsItemId)
       return;
     addNestedEffectsToEffectConfig(activeEffectConfig, $html);
   }


### PR DESCRIPTION
Alt Token Visibility has a setting to let GMs configure a high (total) cover effect. The configuration for the AE has `parent=null` and so it throws an error in the DFred's hook for `renderActiveEffectConfig`. This PR catches that case and simply returns at that point.