### PR TITLE
close 263: Add a button to item cards to quickly apply effects

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -277,3 +277,25 @@ Hooks.on('dropActorSheetData', (actor, _actorSheetCharacter, data) => {
     uuid: actor.uuid,
   });
 });
+
+/**
+ * Handle adding a button to item cards.
+ */
+Hooks.on('renderChatMessage', (message, html) => {
+  const settings = new Settings();
+
+  // only add button on item cards if configured
+  const itemCard = html[0].querySelector('.item-card');
+  if (itemCard && settings.addChatButton) {
+    // check if this item has a Convenient Effect
+    const name = itemCard.querySelector('.item-name')?.textContent;
+    if (game.dfreds.effectInterface.findEffectByName(name)) {
+      // build a button
+      const button = document.createElement('button');
+      button.textContent = 'Add Convenient Effect';
+      button.onclick = () => game.dfreds.effectInterface.toggleEffect(name);
+      // add button to end of card-buttons
+      itemCard.querySelector('.card-buttons').append(button);
+    }
+  }
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -49,8 +49,6 @@ Hooks.once('ready', async () => {
 
     await settings.setCustomEffectsItemId(item.id);
   }
-
-  Hooks.callAll(`${Constants.MODULE_ID}.initialize`);
 });
 
 /**
@@ -101,6 +99,8 @@ Hooks.once('setup', () => {
       game.dfreds.statusEffects.refreshStatusIcons(tokenHud);
     }
   );
+
+  Hooks.callAll(`${Constants.MODULE_ID}.initialize`);
 });
 
 Hooks.on('changeSidebarTab', (directory) => {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -17,6 +17,7 @@ export default class Settings {
   static SHOW_CHAT_MESSAGE_EFFECT_DESCRIPTION = 'chatMessageEffectDescription';
   static SHOW_NESTED_EFFECTS = 'showNestedEffects';
   static STATUS_EFFECTS_SORT_ORDER = 'statusEffectsSortOrder';
+  static ADD_CHAT_BUTTON = 'addChatButton';
 
   // Non-config setting keys
   static CUSTOM_EFFECTS_ITEM_ID = 'customEffectsItemId';
@@ -145,6 +146,19 @@ export default class Settings {
       {
         name: 'Send Chat to Actor Owner',
         hint: 'If enabled, this will also send effect chat messages to the users that own the affected actor.',
+        scope: 'world',
+        config: true,
+        default: false,
+        type: Boolean,
+      }
+    );
+
+    game.settings.register(
+      Constants.MODULE_ID,
+      Settings.ADD_CHAT_BUTTON,
+      {
+        name: 'Add Button to Chat',
+        hint: 'If enabled, add a button to item chat cards to add the matching convenient effect by name.',
         scope: 'world',
         config: true,
         default: false,
@@ -304,6 +318,16 @@ export default class Settings {
       Constants.MODULE_ID,
       Settings.SEND_CHAT_TO_ACTOR_OWNER
     );
+  }
+
+  /**
+   * Returns the game setting for adding a button to chat messages to apply the
+   * matching convenient effect.
+   * 
+   * @returns {boolean} true if the button should be added
+   */
+  get addChatButton() {
+    return game.settings.get(Constants.MODULE_ID, Settings.ADD_CHAT_BUTTON);
   }
 
   /**


### PR DESCRIPTION
Using a `renderChatMessage` hook, add a button to item cards if the name of the item has a matching convenient effect. Since this would interfere with Midi QOL's integration, there is a setting to control this which is off by default. I thought about making it a role-based config setting like `APP_CONTROLS_PERMISSION` is but it didn't seem necessary. In my world script, it was a client setting but it makes more sense here as a world setting. I even thought about checking both this setting and `APP_CONTROLS_PERMISSION` before adding the button but it seemed overkill.

**DO NOT** merge it yet, however. There is a timing issue I'm facing and could use some input on. I'll add a comment w/ that info.