### PR TITLE
Add the option for a unified app button, for both the Convenient Effects app and the Remove Effects app.

### DIFF
--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -27,10 +27,21 @@ export default class Controls {
 
   get _convenientEffectsAppButton() {
     const title = this._showUnifiedRemoval
-      ? `<center><b>Convenient Effects Apps</b></center><hl>
-        <p style="text-align:center"><u>Left mouse click</u>: Opens main CE app</p>
-        <hl><u>Shift+Left mouse click</u>: Opens update CE dialog`
-      : `Add Convenient Effects`;
+      ? `<div class='toolclip'>
+      <h4>DFreds Convenient Effects</h4>
+        <hr class="convenient-effects-fancy-hr">
+        <p>
+          <strong>Convenient Effects:</strong>
+          <span class='reference'>Click</span>
+        </p>
+        <p>
+          <strong>Update Effects:</strong>
+          <span class='reference'>SHIFT + Click</span>
+        </p>
+        <hr class="convenient-effects-fancy-hr">
+        <p class='faint'>Unified Button CE setting</p>
+      </div>`
+      : 'Add Convenient Effects';
     return {
       name: 'convenient-effects',
       title,

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -26,13 +26,11 @@ export default class Controls {
   }
 
   get _convenientEffectsAppButton() {
-    const title =
-      this._settings.unifiedAppButton !== 'none' &&
-      game.user.role >= this._settings.removeControlsPermission
-        ? `<center><b>Convenient Effects Apps</b></center><hl>
+    const title = this._showUnifiedRemoval
+      ? `<center><b>Convenient Effects Apps</b></center><hl>
         <p style="text-align:center"><u>Left mouse click</u>: Opens main CE app</p>
         <hl><u>Shift+Left mouse click</u>: Opens update CE dialog`
-        : `Add Convenient Effects`;
+      : `Add Convenient Effects`;
     return {
       name: 'convenient-effects',
       title,
@@ -40,7 +38,7 @@ export default class Controls {
       button: true,
       visible: this._userAppControlsPermission,
       onClick: () => {
-        if (this._unifiedButton && this._userRemoveControlsPermission) {
+        if (this._showUnifiedRemoval) {
           if (!event.shiftKey) this._handleConvenientEffectsClick();
           else this._handleRemoveEffectsClick();
         } else this._handleConvenientEffectsClick();
@@ -78,5 +76,9 @@ export default class Controls {
 
   get _userRemoveControlsPermission() {
     return game.user.role >= this._settings.removeControlsPermission;
+  }
+
+  get _showUnifiedRemoval() {
+    return this._unifiedButton && this._userRemoveControlsPermission;
   }
 }

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -59,8 +59,8 @@ export default class Controls {
 
   get _removeEffectsButton() {
     return {
-      name: 'remove-convenient-effects',
-      title: 'Remove Convenient Effects',
+      name: 'remove-or-toggle-effects',
+      title: 'Remove or Toggle Effects',
       icon: 'fas fa-trash-alt',
       button: true,
       visible: this._userRemoveControlsPermission,

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -22,17 +22,28 @@ export default class Controls {
     if (!tokenButton) return;
 
     tokenButton.tools.push(this._convenientEffectsAppButton);
-    tokenButton.tools.push(this._removeEffectsButton);
+    if (this._settings.unifiedAppButton === 'none') tokenButton.tools.push(this._removeEffectsButton);
   }
 
   get _convenientEffectsAppButton() {
+    const title = this._settings.unifiedAppButton !== 'none' && game.user.role >= this._settings.removeControlsPermission
+      ? `<center><b>DFreds CE Apps</b></center><hl>
+        <p style="text-align:center"><u>Left mouse click</u>: Opens Add CE</p>
+        <hl><u>${this._settings.unifiedAppButton}+Left mouse click</u>: Opens Update CE`
+      : `Add Convenient Effects`;
     return {
       name: 'convenient-effects',
-      title: 'Add Convenient Effects',
+      title,
       icon: 'fas fa-hand-sparkles',
       button: true,
       visible: game.user.role >= this._settings.appControlsPermission,
-      onClick: this._handleConvenientEffectsClick,
+      onClick: () => {
+        if (this._settings.unifiedAppButton !== 'none' && game.user.role >= this._settings.removeControlsPermission) {
+          if (!event[this._settings.unifiedAppButton]) this._handleConvenientEffectsClick()
+          else this._handleRemoveEffectsClick()  
+        }
+        else this._handleConvenientEffectsClick()  
+      },
     };
   }
 

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -22,27 +22,28 @@ export default class Controls {
     if (!tokenButton) return;
 
     tokenButton.tools.push(this._convenientEffectsAppButton);
-    if (this._settings.unifiedAppButton === 'none') tokenButton.tools.push(this._removeEffectsButton);
+    if (!this._unifiedButton) tokenButton.tools.push(this._removeEffectsButton);
   }
 
   get _convenientEffectsAppButton() {
-    const title = this._settings.unifiedAppButton !== 'none' && game.user.role >= this._settings.removeControlsPermission
-      ? `<center><b>DFreds CE Apps</b></center><hl>
+    const title =
+      this._settings.unifiedAppButton !== 'none' &&
+      game.user.role >= this._settings.removeControlsPermission
+        ? `<center><b>Convenient Effects Apps</b></center><hl>
         <p style="text-align:center"><u>Left mouse click</u>: Opens Add CE</p>
-        <hl><u>${this._settings.unifiedAppButton}+Left mouse click</u>: Opens Update CE`
-      : `Add Convenient Effects`;
+        <hl><u>Shift+Left mouse click</u>: Opens Update CE`
+        : `Add Convenient Effects`;
     return {
       name: 'convenient-effects',
       title,
       icon: 'fas fa-hand-sparkles',
       button: true,
-      visible: game.user.role >= this._settings.appControlsPermission,
+      visible: this._userAppControlsPermission,
       onClick: () => {
-        if (this._settings.unifiedAppButton !== 'none' && game.user.role >= this._settings.removeControlsPermission) {
-          if (!event[this._settings.unifiedAppButton]) this._handleConvenientEffectsClick()
-          else this._handleRemoveEffectsClick()  
-        }
-        else this._handleConvenientEffectsClick()  
+        if (this._unifiedButton && this._userRemoveControlsPermission) {
+          if (!event.shiftKey) this._handleConvenientEffectsClick();
+          else this._handleRemoveEffectsClick();
+        } else this._handleConvenientEffectsClick();
       },
     };
   }
@@ -51,19 +52,31 @@ export default class Controls {
     new ConvenientEffectsApp().render(true);
   }
 
+  async _handleRemoveEffectsClick() {
+    const removeEffectsHandler = new RemoveEffectsHandler();
+    return removeEffectsHandler.handle();
+  }
+
   get _removeEffectsButton() {
     return {
-      name: 'remove-or-toggle-effects',
-      title: 'Remove or Toggle Effects',
+      name: 'remove-convenient-effects',
+      title: 'Remove Convenient Effects',
       icon: 'fas fa-trash-alt',
       button: true,
-      visible: game.user.role >= this._settings.removeControlsPermission,
+      visible: this._userRemoveControlsPermission,
       onClick: this._handleRemoveEffectsClick,
     };
   }
 
-  async _handleRemoveEffectsClick() {
-    const removeEffectsHandler = new RemoveEffectsHandler();
-    return removeEffectsHandler.handle();
+  get _unifiedButton() {
+    return this._settings.unifiedAppButton;
+  }
+
+  get _userAppControlsPermission() {
+    return game.user.role >= this._settings.appControlsPermission;
+  }
+
+  get _userRemoveControlsPermission() {
+    return game.user.role >= this._settings.removeControlsPermission;
   }
 }

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -39,7 +39,7 @@ export default class Controls {
           <span class='reference'>SHIFT + Click</span>
         </p>
         <hr class="convenient-effects-fancy-hr">
-        <p class='faint'>Unified Button CE setting</p>
+        <p class='faint-convenient-effects'>Unified Button CE setting</p>
       </div>`
       : 'Add Convenient Effects';
     return {

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -30,8 +30,8 @@ export default class Controls {
       this._settings.unifiedAppButton !== 'none' &&
       game.user.role >= this._settings.removeControlsPermission
         ? `<center><b>Convenient Effects Apps</b></center><hl>
-        <p style="text-align:center"><u>Left mouse click</u>: Opens Add CE</p>
-        <hl><u>Shift+Left mouse click</u>: Opens Update CE`
+        <p style="text-align:center"><u>Left mouse click</u>: Opens main CE app</p>
+        <hl><u>Shift+Left mouse click</u>: Opens update CE dialog`
         : `Add Convenient Effects`;
     return {
       name: 'convenient-effects',

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -72,15 +72,19 @@ export default class Settings {
       }
     );
 
-    game.settings.register(Constants.MODULE_ID, Settings.ADD_UNIFIED_BUTTON, {
-      name: 'Unified App Button',
-      hint: 'Note: This setting will have no effect if the Remove controls permission is not enough for the individual client accessing the buttons. Otherwise, this defines whether there is a single button on the token controls for both the apply and remove DFreds applications.',
-      scope: 'world',
-      config: true,
-      default: false,
-      type: Boolean,
-      requiresReload: true,
-    });
+    game.settings.register(
+    Constants.MODULE_ID,
+    Settings.ADD_UNIFIED_BUTTON,
+      {
+        name: 'Unified App Button',
+        hint: 'Note: This setting will have no effect if the Remove controls permission is not enough for the individual client accessing the buttons. Otherwise, this defines whether there is a single button on the token controls for both the apply and remove DFreds applications.',
+        scope: 'world',
+        config: true,
+        default: false,
+        type: Boolean,
+        requiresReload: true,
+      }
+    );
 
     game.settings.register(
       Constants.MODULE_ID,
@@ -164,14 +168,18 @@ export default class Settings {
       }
     );
 
-    game.settings.register(Constants.MODULE_ID, Settings.ADD_CHAT_BUTTON, {
-      name: 'Add Button to Chat',
-      hint: 'If enabled, add a button to item chat cards to add the matching convenient effect by name.',
-      scope: 'world',
-      config: true,
-      default: false,
-      type: Boolean,
-    });
+    game.settings.register(
+      Constants.MODULE_ID, 
+      Settings.ADD_CHAT_BUTTON, 
+      {
+        name: 'Add Button to Chat',
+        hint: 'If enabled, add a button to item chat cards to add the matching convenient effect by name.',
+        scope: 'world',
+        config: true,
+        default: false,
+        type: Boolean,
+      }
+    );
 
     game.settings.register(
       Constants.MODULE_ID,

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -169,8 +169,8 @@ export default class Settings {
     );
 
     game.settings.register(
-      Constants.MODULE_ID, 
-      Settings.ADD_CHAT_BUTTON, 
+      Constants.MODULE_ID,
+      Settings.ADD_CHAT_BUTTON,
       {
         name: 'Add Button to Chat',
         hint: 'If enabled, add a button to item chat cards to add the matching convenient effect by name.',

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -359,10 +359,13 @@ export default class Settings {
   /**
    * Returns the game setting for unified app controls button
    *
-   * @returns {string} returns a string representing the option selected
+   * @returns {boolean} true if the unified button is enabled
    */
   get unifiedAppButton() {
-    return game.settings.get(Constants.MODULE_ID, Settings.ADD_UNIFIED_BUTTON);
+    return game.settings.get(
+      Constants.MODULE_ID,
+      Settings.ADD_UNIFIED_BUTTON
+    );
   }
 
   /**

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -18,6 +18,7 @@ export default class Settings {
   static SHOW_NESTED_EFFECTS = 'showNestedEffects';
   static STATUS_EFFECTS_SORT_ORDER = 'statusEffectsSortOrder';
   static ADD_CHAT_BUTTON = 'addChatButton';
+  static ADD_UNIFIED_BUTTON = 'addUnifiedButton';
 
   // Non-config setting keys
   static CUSTOM_EFFECTS_ITEM_ID = 'customEffectsItemId';
@@ -67,6 +68,26 @@ export default class Settings {
         default: CONST.USER_ROLES.GAMEMASTER,
         choices: userRoles,
         type: String,
+        requiresReload: true,
+      }
+    );
+
+    game.settings.register(
+      Constants.MODULE_ID,
+      Settings.ADD_UNIFIED_BUTTON,
+      {
+        name: 'Unified App Button',
+        hint: 'Note: This setting will have no effect if the Remove controls permission is not enough for the individual client accessing the buttons. Otherwise, this defines whether there is a single button on the token controls for both the apply and remove DFreds applications.',
+        scope: 'world',
+        config: true,
+        default: 'none',
+        type: String,
+        choices: {
+          none: 'No',
+          shiftKey: 'Yes: shift key + Left mouse click for Update DFreds CE app',
+          altKey: 'Yes: alt key + Left mouse click for Update DFreds CE app',
+          ctrlKey: 'Yes: ctrl key + Left mouse click for Update DFreds CE app'
+        },
         requiresReload: true,
       }
     );
@@ -338,6 +359,18 @@ export default class Settings {
   get appControlsPermission() {
     return parseInt(
       game.settings.get(Constants.MODULE_ID, Settings.APP_CONTROLS_PERMISSION)
+    );
+  }
+
+  /**
+   * Returns the game setting for unified app controls button
+   *
+   * @returns {boolen} true if the button should be unified
+   */
+  get unifiedAppButton() {
+    return game.settings.get(
+      Constants.MODULE_ID,
+      Settings.ADD_UNIFIED_BUTTON
     );
   }
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -72,25 +72,15 @@ export default class Settings {
       }
     );
 
-    game.settings.register(
-      Constants.MODULE_ID,
-      Settings.ADD_UNIFIED_BUTTON,
-      {
-        name: 'Unified App Button',
-        hint: 'Note: This setting will have no effect if the Remove controls permission is not enough for the individual client accessing the buttons. Otherwise, this defines whether there is a single button on the token controls for both the apply and remove DFreds applications.',
-        scope: 'world',
-        config: true,
-        default: 'none',
-        type: String,
-        choices: {
-          none: 'No',
-          shiftKey: 'Yes: shift key + Left mouse click for Update DFreds CE app',
-          altKey: 'Yes: alt key + Left mouse click for Update DFreds CE app',
-          ctrlKey: 'Yes: ctrl key + Left mouse click for Update DFreds CE app'
-        },
-        requiresReload: true,
-      }
-    );
+    game.settings.register(Constants.MODULE_ID, Settings.ADD_UNIFIED_BUTTON, {
+      name: 'Unified App Button',
+      hint: 'Note: This setting will have no effect if the Remove controls permission is not enough for the individual client accessing the buttons. Otherwise, this defines whether there is a single button on the token controls for both the apply and remove DFreds applications.',
+      scope: 'world',
+      config: true,
+      default: false,
+      type: Boolean,
+      requiresReload: true,
+    });
 
     game.settings.register(
       Constants.MODULE_ID,
@@ -174,18 +164,14 @@ export default class Settings {
       }
     );
 
-    game.settings.register(
-      Constants.MODULE_ID,
-      Settings.ADD_CHAT_BUTTON,
-      {
-        name: 'Add Button to Chat',
-        hint: 'If enabled, add a button to item chat cards to add the matching convenient effect by name.',
-        scope: 'world',
-        config: true,
-        default: false,
-        type: Boolean,
-      }
-    );
+    game.settings.register(Constants.MODULE_ID, Settings.ADD_CHAT_BUTTON, {
+      name: 'Add Button to Chat',
+      hint: 'If enabled, add a button to item chat cards to add the matching convenient effect by name.',
+      scope: 'world',
+      config: true,
+      default: false,
+      type: Boolean,
+    });
 
     game.settings.register(
       Constants.MODULE_ID,
@@ -344,7 +330,7 @@ export default class Settings {
   /**
    * Returns the game setting for adding a button to chat messages to apply the
    * matching convenient effect.
-   * 
+   *
    * @returns {boolean} true if the button should be added
    */
   get addChatButton() {
@@ -368,10 +354,7 @@ export default class Settings {
    * @returns {string} returns a string representing the option selected
    */
   get unifiedAppButton() {
-    return game.settings.get(
-      Constants.MODULE_ID,
-      Settings.ADD_UNIFIED_BUTTON
-    );
+    return game.settings.get(Constants.MODULE_ID, Settings.ADD_UNIFIED_BUTTON);
   }
 
   /**

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -365,7 +365,7 @@ export default class Settings {
   /**
    * Returns the game setting for unified app controls button
    *
-   * @returns {boolen} true if the button should be unified
+   * @returns {string} returns a string representing the option selected
    */
   get unifiedAppButton() {
     return game.settings.get(

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -77,7 +77,7 @@ export default class Settings {
     Settings.ADD_UNIFIED_BUTTON,
       {
         name: 'Unified App Button',
-        hint: 'Note: This setting will have no effect if the Remove controls permission is not enough for the individual client accessing the buttons. Otherwise, this defines whether there is a single button on the token controls for both the apply and remove DFreds applications.',
+        hint: 'Note: This setting will have no effect if the Remove controls permission is not enough for the individual client accessing the buttons. Otherwise, this defines whether there is a single button on the token controls for both the apply (Left Click) and remove/toggle (Shift + Left Click) DFreds applications.',
         scope: 'world',
         config: true,
         default: false,

--- a/styles/dfreds-convenient-effects.css
+++ b/styles/dfreds-convenient-effects.css
@@ -42,4 +42,32 @@
   line-height: 24px;
   margin: -1px 0 -1px 4px;
   order: 99;
-} 
+}
+
+.convenient-effects-chat-header {
+  margin-bottom: 1px !important;
+  margin-top: 5px !important;
+}
+
+.convenient-effects-chat-description {
+  margin-bottom: 5px !important;
+  margin-top: 5px !important;
+  text-size-adjust: 80%;
+}
+
+.convenient-effects-fancy-hr {
+  border: 0;
+  height: 1px;
+  background-image: -webkit-linear-gradient(left, #f0f0f0, #8c8b8b, #f0f0f0);
+  background-image: -moz-linear-gradient(left, #f0f0f0, #8c8b8b, #f0f0f0);
+  background-image: -ms-linear-gradient(left, #f0f0f0, #8c8b8b, #f0f0f0);
+  background-image: -o-linear-gradient(left, #f0f0f0, #8c8b8b, #f0f0f0);
+}
+
+/*Slightly adjusting the Foundry the p.faint tooltip text size*/
+#tooltip .toolclip p.faint-convenient-effects,
+.locked-tooltip .toolclip p.faint-convenient-effects {
+  text-align: center;
+  font-size: 10px;
+  color: var(--color-text-light-heading);
+}


### PR DESCRIPTION
This is a personal preference to save sidebar buttons real estate, which you might find interesting.
It breaks Foundry convention of one sidebar button one function, so it is totally understandable if this isn't implemented in the end 👍 

Note: It has some mentions to additions made in the https://github.com/DFreds/dfreds-convenient-effects/pull/282 , which even though not breaking, might be a bit conflicting.

- Remove the secondary button added by DFreds remove effects app and using an event to open it if needed.
- Add a World setting for choosing to unify the buttons and choose the relevant key to use alongside left mouse click to open the remove effects app.
- Will respect the settings for visibility of the apps based on `game.user.role`

![image](https://github.com/DFreds/dfreds-convenient-effects/assets/7237090/2227d479-7ea6-41a1-9ecf-135b6ad8bc4f)
![image](https://github.com/DFreds/dfreds-convenient-effects/assets/7237090/8419abc2-24b4-45cf-8c2d-59808cffa44e)

![image](https://github.com/DFreds/dfreds-convenient-effects/assets/7237090/55527701-c9d7-48c4-a71e-5f2c3125d8dc)![image](https://github.com/DFreds/dfreds-convenient-effects/assets/7237090/95a9c100-df67-4156-8858-eb69fd413551)

