### PR TITLE
Seems that activeEffectConfig.object.parent can be null

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -244,7 +244,7 @@ Hooks.on('closeActiveEffectConfig', (activeEffectConfig, _html) => {
   const settings = new Settings();
 
   // Only re-render if the effect exists on the custom effect
-  if (activeEffectConfig.object.parent.id != settings.customEffectsItemId)
+  if (activeEffectConfig.object.parent?.id != settings.customEffectsItemId)
     return;
 
   const foundryHelpers = new FoundryHelpers();


### PR DESCRIPTION
Alternative token visibility module has a small Active effect app in its config menu, which when closed triggers this error. 

Small fix to improve compatibility 
```js
foundry.js:753  TypeError: Error thrown in hooked function '' for hook 'closeActiveEffectConfig'. Cannot read properties of null (reading 'id')
    at Object.fn (main.js:247:40)
    at #call (foundry.js:730:20)
    at Hooks.call (foundry.js:712:38)
    at HighCoverEffectConfig.close (foundry.js:6129:13)
    at HighCoverEffectConfig.close (foundry.js:6854:18)
    at HighCoverEffectConfig.close (foundry.js:6967:17)
    at Object.onclick (foundry.js:5955:29)
    at HTMLAnchorElement.<anonymous> (foundry.js:5863:16)
    at HTMLAnchorElement.dispatch (jquery.min.js:2:43184)
    at y.handle (jquery.min.js:2:41168)
```