### PR TITLE
add handling for item card rolls with no .card-buttons element

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -294,6 +294,16 @@ Hooks.on('renderChatMessage', (message, html) => {
       const button = document.createElement('button');
       button.textContent = 'Add Convenient Effect';
       button.onclick = () => game.dfreds.effectInterface.toggleEffect(name);
+
+      // construct empty card-buttons if it doesn't exist (e.g. quick-roll from Ready Set Roll)
+      if (!itemCard.querySelector('.card-buttons')) {  
+          const div = document.createElement('div');
+          div.classList.add('card-buttons');
+      
+          let cardContent = itemCard.querySelector('.card-content');
+          cardContent.insertAdjacentElement('afterend', div);
+      }
+
       // add button to end of card-buttons
       itemCard.querySelector('.card-buttons').append(button);
     }


### PR DESCRIPTION
When using the quick roll functionality from Ready Set Roll, there is no .card-buttons element.  Thus, even if the user has enabled the "Add Chat Buttons" option, the buttons will not be rendered.  This change checks for the presence of the .card-buttons element, and inserts a blank element prior to adding the "Add Convenient Effect" button if there is no .card-buttons element.